### PR TITLE
Add Chase World of Hyatt Visa

### DIFF
--- a/Sources/App/Data/Cards.swift
+++ b/Sources/App/Data/Cards.swift
@@ -1322,6 +1322,35 @@ extension Card {
                 ],
                 network: .mastercard
             ),
+            Card(
+                id: "world-of-hyatt",
+                name: "World of Hyatt",
+                icon: .gray,
+                issuer: .chase,
+                basePoints: [.init(multiplier: 1)],
+                categoryPoints: [
+                    SpendCategory.hyatt.id: [.init(multiplier: 4)],
+                    SpendCategory.dining.id: [.init(multiplier: 2)],
+                    SpendCategory.flights.id: [
+                        .init(
+                            multiplier: 2,
+                            attributes: [
+                                .caveat("On airline tickets purchased directly from the airline"),
+                            ]
+                        ),
+                    ],
+                    SpendCategory.transit.id: [
+                        .init(
+                            multiplier: 2,
+                            attributes: [
+                                .caveat("On local transit and commuting"),
+                            ]
+                        ),
+                    ],
+                    SpendCategory.fitness.id: [.init(multiplier: 2)],
+                ],
+                network: .visa
+            ),
         ].sorted {
             (
                 $0.issuer.name,

--- a/Sources/App/Data/SpendCategories.swift
+++ b/Sources/App/Data/SpendCategories.swift
@@ -24,6 +24,7 @@ extension SpendCategory {
         .advertising,
         .entertainment,
         .streaming,
+        .fitness,
         .amazon,
         .costco,
         .apple,
@@ -37,6 +38,7 @@ extension SpendCategory {
         .southwest,
         .united,
         .hotels,
+        .hyatt,
         .carRentals,
         .lyft,
         .transit,
@@ -244,5 +246,18 @@ extension SpendCategory {
         id: "shipping",
         name: "Shipping",
         tint: .brown
+    )
+
+    static let hyatt = SpendCategory(
+        id: "hyatt",
+        name: "Hyatt Hotels",
+        tint: .blue,
+        parent: SpendCategory.travel.id
+    )
+
+    static let fitness = SpendCategory(
+        id: "fitness",
+        name: "Fitness Club and Gym Memberships",
+        tint: .red
     )
 }


### PR DESCRIPTION
### Credit Card Details

This adds support for the World of Hyatt card from Chase. [Details](https://creditcards.chase.com/travel-credit-cards/world-of-hyatt-credit-card)

I added two new SpendCategories to capture some of the Hyatt card's unique perks.

I don't have a Swift dev environment — I hope I've avoided syntax errors but I haven't run this through a compiler.

- [x] Check that the card is not already present
- [x] Specify which card is being added in the PR
- [x] Double check the reward details
- [x] Include a link to the card details
